### PR TITLE
Fix Memory Leak from default link

### DIFF
--- a/lib/deferred_pointer_handler.dart
+++ b/lib/deferred_pointer_handler.dart
@@ -39,6 +39,12 @@ class DeferredPointerHandlerState extends State<DeferredPointerHandler> {
       child: _DeferredHitTargetRenderObjectWidget(link: widget.link ?? _link, child: widget.child),
     );
   }
+
+  @override
+  void dispose() {
+    _link.dispose();
+    super.dispose();
+  }
 }
 
 ////////////////////////////////


### PR DESCRIPTION
## Overview
Fix memory leak from default link in defer pointer handler widget.
it's lifetime is the same as the widget, no other hooks are provided or should be used when using this default link